### PR TITLE
fixed issue causing `parameter.default: ""` to become `"{}"`

### DIFF
--- a/ssm_dox/models/parameter.py
+++ b/ssm_dox/models/parameter.py
@@ -1,7 +1,7 @@
 """AWS SSM Document parameter data model."""
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Optional, Union, cast
+from typing import Any, Dict, List, Literal, Optional, cast
 
 from pydantic import validator
 
@@ -19,17 +19,7 @@ class SsmDocumentParameterDataModel(BaseModel):
 
     allowedPattern: Optional[str] = None
     allowedValues: Optional[List[str]] = None
-    default: Optional[
-        Union[
-            bool,
-            List[Dict[str, str]],
-            List[str],
-            Dict[str, str],
-            Dict[str, List[str]],
-            int,
-            str,
-        ]
-    ] = None
+    default: Any = None
     description: Optional[str] = None
     displayType: Optional[Literal["textarea", "testfield"]] = None
     maxChars: Optional[int] = None

--- a/tests/unit/models/test_parameter.py
+++ b/tests/unit/models/test_parameter.py
@@ -11,7 +11,7 @@ from ssm_dox.models.parameter import SsmDocumentParameterDataModel
 class TestSsmDocumentParameterDataModel:
     """Test SsmDocumentParameterDataModel."""
 
-    @pytest.mark.parametrize("value", [False, 0, "False", ""])
+    @pytest.mark.parametrize("value", [False, 0, ""])
     def test_default_bool_false(self, value: Any) -> None:
         """Test default bool."""
         obj = SsmDocumentParameterDataModel.parse_obj(
@@ -19,7 +19,7 @@ class TestSsmDocumentParameterDataModel:
         )
         assert obj.default is False
 
-    @pytest.mark.parametrize("value", ["test", 13, "13", True, "True"])
+    @pytest.mark.parametrize("value", ["test", 13, "13", True, "False", "True"])
     def test_default_bool_true(self, value: Any) -> None:
         """Test default bool."""
         obj = SsmDocumentParameterDataModel.parse_obj(
@@ -56,7 +56,7 @@ class TestSsmDocumentParameterDataModel:
         assert error["loc"] == ("default",)
         assert error["type"] == "type_error"
 
-    @pytest.mark.parametrize("value", [None, "test", 13, "13", True, False])
+    @pytest.mark.parametrize("value", [None, "test", 13, "13", True, False, ""])
     def test_default_string(self, value: Any) -> None:
         """Test default."""
         obj = SsmDocumentParameterDataModel.parse_obj(


### PR DESCRIPTION
# Summary

Parameter default value of `""` was being converted into `"{}"` when dumping to json.

# What Changed

## Fixed

- fixed issue causing `parameter.default: ""` to become `"{}"`

